### PR TITLE
Fix typo of the first word of the first paragraph of the preface

### DIFF
--- a/book_src/Operating System From 0 to 1.lyx
+++ b/book_src/Operating System From 0 to 1.lyx
@@ -407,7 +407,7 @@ addcontentsline{toc}{chapter}{Preface}
 \begin_layout Standard
 \noindent
 \align left
-Greeting!
+Greetings!
 \end_layout
 
 \begin_layout Standard


### PR DESCRIPTION
Heyas~!

I started reading the book,  and the first thing I saw in the preface was:

```LATEX
Greeting!
```

This pull request changes that to:

```LATEX
Greetings!
```