### PR TITLE
[README.md] [Typo] Fix a link title (and remove a trailing whitespace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ C programming. In particular:
 
 + Fundamental algorithms and data structures in C
 
-Linux basics: 
+Linux basics:
 
 + Know how to navigate directory with the command line
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ the [minimum requirement](http://wiki.osdev.org/Required_Knowledge) by OSDev
 Wiki (well, not quite, the book actually goes deeper for the suggested topics).
 Or, if you consider developing an OS for fun is impractical, you can continue
 with a Linux-specific book, such as this free
-book [Linux Insiders](https://0xax.gitbooks.io/linux-insides/content/), or other
+book [Linux Insides](https://0xax.gitbooks.io/linux-insides/content/), or other
 popular Linux kernel books. The book tries hard to provide you a strong
 foundation, and that's why part 1 and part 2 were released first.
 


### PR DESCRIPTION

On this page https://www.gitbook.com/book/0xax/linux-insides/details

You can see 'Linux Inside', but I guess it would prefer to 'Linux Insides'

![image](https://cloud.githubusercontent.com/assets/5820754/23331507/bb37cffe-fbaa-11e6-98f6-0351dcf7a213.png)
