### PR TITLE
Use option -j of objdump(1) to display only .data and .bss sections

### DIFF
--- a/book_src/Operating Systems From 0 to 1.lyx
+++ b/book_src/Operating Systems From 0 to 1.lyx
@@ -51561,7 +51561,7 @@ typedef void (*init)();
 
 \begin_layout Plain Layout
 
-__attribute__((section(".init_array"))) preinit preinit_arr[2] = {preinit1,
+__attribute__((section(".preinit_array"))) preinit preinit_arr[2] = {preinit1,
  preinit2};
 \end_layout
 

--- a/book_src/Operating Systems From 0 to 1.lyx
+++ b/book_src/Operating Systems From 0 to 1.lyx
@@ -30227,7 +30227,7 @@ begin{tcolorbox}[enlarge top initially by=5mm]
 \begin_layout Standard
 
 \family typewriter
-$ objdump -z -M intel -S -D <object file> | less
+$ objdump -z -M intel -S -D -j .data -j .bss <object file> | less
 \end_layout
 
 \begin_layout Standard

--- a/book_src/Operating Systems From 0 to 1.txt
+++ b/book_src/Operating Systems From 0 to 1.txt
@@ -3468,7 +3468,7 @@ in this section will be:
 
 
 
-$ objdump -z -M intel -S -D <object file> | less
+$ objdump -z -M intel -S -D -j .data -j .bss <object file> | less
 
 
 

--- a/book_src/Operating Systems From 0 to 1.txt
+++ b/book_src/Operating Systems From 0 to 1.txt
@@ -7630,7 +7630,7 @@ typedef void (*init)();
 
 
 
-__attribute__((section(".init_array"))) preinit preinit_arr[2] = 
+__attribute__((section(".preinit_array"))) preinit preinit_arr[2] = 
 {preinit1, preinit2};
 
 __attribute__((section(".init_array"))) init init_arr[2] = 


### PR DESCRIPTION
Hello.
Great thanks for your book. I really enjoy reading it.
When I executed the objdump command from the section 4.8 "Examine compiled data" `objdump -z -M intel -S -D <object file> | less`, I saw the full output. I think, this is a little not comfortable to flip the entire output to look up a needed piece.
So, I propose you specify needed sections (.data and .bss) with -j option.
Thanks.

With best regards,
Dmitry